### PR TITLE
Fix non us state boundaries 65

### DIFF
--- a/src/main/java/org/openmaptiles/generated/OpenMapTilesSchema.java
+++ b/src/main/java/org/openmaptiles/generated/OpenMapTilesSchema.java
@@ -696,6 +696,7 @@ public class OpenMapTilesSchema {
        * </ul>
        */
       public static final String DISPUTED = "disputed";
+      public static final String COUNTRY_CODE_A2 = "ISO3166-2";
       public static final String COUNTRY_CODE_A3 = "ISO3166-1";
 
       /**

--- a/src/main/java/org/openmaptiles/generated/OpenMapTilesSchema.java
+++ b/src/main/java/org/openmaptiles/generated/OpenMapTilesSchema.java
@@ -696,6 +696,7 @@ public class OpenMapTilesSchema {
        * </ul>
        */
       public static final String DISPUTED = "disputed";
+      public static final String COUNTRY_CODE_A3 = "ISO3166-1";
 
       /**
        * Field containing name of the disputed area (extracted from border relation in OSM, without spaces). For country

--- a/src/main/java/org/openmaptiles/layers/Boundary.java
+++ b/src/main/java/org/openmaptiles/layers/Boundary.java
@@ -203,6 +203,7 @@ public class Boundary implements
       relation.hasTag("boundary", "administrative")) {
       Integer adminLevelValue = Parse.parseRoundInt(relation.getTag("admin_level"));
       String code = relation.getString("ISO3166-1:alpha3");
+      String iso_a2 = relation.getString("ISO3166-2");
       if (adminLevelValue != null && adminLevelValue >= 2 && adminLevelValue <= 10) {
         boolean disputed = isDisputed(relation.tags());
         if (code != null) {
@@ -214,7 +215,8 @@ public class Boundary implements
           disputed,
           relation.getString("name"),
           disputed ? relation.getString("claimed_by") : null,
-          code
+          code,
+          iso_a2
         ));
       }
     }
@@ -230,6 +232,7 @@ public class Boundary implements
     if (!relationInfos.isEmpty()) {
       int minAdminLevel = Integer.MAX_VALUE;
       String disputedName = null, claimedBy = null;
+      String iso_a2 = null;
       Set<Long> regionIds = new HashSet<>();
       boolean disputed = false;
       // aggregate all borders this way is a part of - take the lowest
@@ -247,6 +250,9 @@ public class Boundary implements
         if (minAdminLevel == 2 && regionNames.containsKey(info.relation().id)) {
           regionIds.add(info.relation().id);
         }
+        if (minAdminLevel == 4 && iso_a2 == null) {
+        iso_a2 = rel.iso3166_2;
+       }
       }
 
       if (minAdminLevel <= 10) {
@@ -301,6 +307,7 @@ public class Boundary implements
             .setMinPixelSizeAtAllZooms(0)
             .setMinZoom(minzoom)
             .setAttr(Fields.CLAIMED_BY, claimedBy)
+            .setAttr(Fields.COUNTRY_CODE_A2, iso_a2)
             .setAttr(Fields.DISPUTED_NAME, editName(disputedName));
         }
       }
@@ -458,7 +465,8 @@ public class Boundary implements
     boolean disputed,
     String name,
     String claimedBy,
-    String iso3166alpha3
+    String iso3166alpha3,
+    String iso3166_2
   ) implements OsmRelationInfo {
 
     @Override

--- a/src/main/java/org/openmaptiles/layers/Boundary.java
+++ b/src/main/java/org/openmaptiles/layers/Boundary.java
@@ -251,8 +251,8 @@ public class Boundary implements
           regionIds.add(info.relation().id);
         }
         if (minAdminLevel == 4 && iso_a2 == null) {
-        iso_a2 = rel.iso3166_2;
-       }
+          iso_a2 = rel.iso3166_2;
+        }
       }
 
       if (minAdminLevel <= 10) {

--- a/src/main/java/org/openmaptiles/layers/Boundary.java
+++ b/src/main/java/org/openmaptiles/layers/Boundary.java
@@ -170,16 +170,17 @@ public class Boundary implements
       return;
     }
     boolean disputed = feature.getString("featurecla", "").startsWith("Disputed");
-    record BoundaryInfo(int adminLevel, int minzoom, int maxzoom) {}
+    record BoundaryInfo(int adminLevel, int minzoom, int maxzoom, String iso_a3) {}
     BoundaryInfo info = switch (table) {
-      case "ne_110m_admin_0_boundary_lines_land" -> new BoundaryInfo(2, 0, 0);
-      case "ne_50m_admin_0_boundary_lines_land" -> new BoundaryInfo(2, 1, 3);
+      case "ne_110m_admin_0_boundary_lines_land" -> new BoundaryInfo(2, 0, 0, null);
+      case "ne_50m_admin_0_boundary_lines_land" -> new BoundaryInfo(2, 1, 3, null);
       case "ne_10m_admin_0_boundary_lines_land" -> feature.hasTag("featurecla", "Lease Limit") ? null :
-        new BoundaryInfo(2, 4, 4);
+        new BoundaryInfo(2, 4, 4, null);
       case "ne_10m_admin_1_states_provinces_lines" -> {
         Double minZoom = Parse.parseDoubleOrNull(feature.getTag("min_zoom"));
-        yield minZoom != null && minZoom <= 7 ? new BoundaryInfo(4, 1, 4) :
-          minZoom != null && minZoom <= 7.7 ? new BoundaryInfo(4, 4, 4) :
+        String iso_a3 = feature.getString("adm0_a3");
+        yield minZoom != null && minZoom <= 7 ? new BoundaryInfo(4, 1, 4, iso_a3) :
+          minZoom != null && minZoom <= 7.7 ? new BoundaryInfo(4, 4, 4, iso_a3) :
           null;
       }
       default -> null;
@@ -190,6 +191,7 @@ public class Boundary implements
         .setMinPixelSizeAtAllZooms(0)
         .setAttr(Fields.ADMIN_LEVEL, info.adminLevel)
         .setAttr(Fields.MARITIME, 0)
+        .setAttr(Fields.COUNTRY_CODE_A3, info.iso_a3)
         .setAttr(Fields.DISPUTED, disputed ? 1 : 0);
     }
   }

--- a/src/test/java/org/openmaptiles/layers/BoundaryTest.java
+++ b/src/test/java/org/openmaptiles/layers/BoundaryTest.java
@@ -254,13 +254,15 @@ class BoundaryTest extends AbstractLayerTest {
     relation2.setTag("admin_level", "4");
     relation2.setTag("name", "State");
     relation2.setTag("boundary", "administrative");
+    relation2.setTag("ISO3166-2", "US-CA");
 
     assertFeatures(14, List.of(Map.of(
       "_layer", "boundary",
       "_type", "line",
       "disputed", 0,
       "maritime", 0,
-      "admin_level", 4
+      "admin_level", 4,
+      "ISO3166-2", "US-CA"
     )), process(lineFeatureWithRelation(
       Stream.concat(
         profile.preprocessOsmRelation(relation2).stream(),

--- a/src/test/java/org/openmaptiles/layers/BoundaryTest.java
+++ b/src/test/java/org/openmaptiles/layers/BoundaryTest.java
@@ -134,6 +134,7 @@ class BoundaryTest extends AbstractLayerTest {
       "disputed", 0,
       "maritime", 0,
       "admin_level", 4,
+      "ISO3166-1", "USA",
 
       "_minzoom", 1,
       "_maxzoom", 4,
@@ -141,7 +142,8 @@ class BoundaryTest extends AbstractLayerTest {
     )), process(SimpleFeature.create(
       newLineString(0, 0, 1, 1),
       Map.of(
-        "min_zoom", 7d
+        "min_zoom", 7d,
+        "adm0_a3", "USA"
       ),
       OpenMapTilesProfile.NATURAL_EARTH_SOURCE,
       "ne_10m_admin_1_states_provinces_lines",
@@ -153,6 +155,7 @@ class BoundaryTest extends AbstractLayerTest {
       "disputed", 0,
       "maritime", 0,
       "admin_level", 4,
+      "ISO3166-1", "GBR",
 
       "_minzoom", 4,
       "_maxzoom", 4,
@@ -160,7 +163,8 @@ class BoundaryTest extends AbstractLayerTest {
     )), process(SimpleFeature.create(
       newLineString(0, 0, 1, 1),
       Map.of(
-        "min_zoom", 7.6d
+        "min_zoom", 7.6d,
+        "adm0_a3", "GBR"
       ),
       OpenMapTilesProfile.NATURAL_EARTH_SOURCE,
       "ne_10m_admin_1_states_provinces_lines",


### PR DESCRIPTION
Include country code attribute for states in Boundary layer. This will allow for country specific styling of state boundaries

Part of addressing https://github.com/nmr8acme/acme-vector-styles/issues/65