### PR TITLE
Include US County borders from z4

### DIFF
--- a/src/main/java/org/openmaptiles/layers/Boundary.java
+++ b/src/main/java/org/openmaptiles/layers/Boundary.java
@@ -166,7 +166,7 @@ public class Boundary implements
 
   private static boolean isUsCountyBorder(OsmElement.Relation relation) {
     return relation.hasTag("nist:fips_code") ||
-    relation.hasTag("gnis:feature_id");
+      relation.hasTag("gnis:feature_id");
   }
 
   @Override

--- a/src/main/java/org/openmaptiles/layers/Boundary.java
+++ b/src/main/java/org/openmaptiles/layers/Boundary.java
@@ -164,6 +164,11 @@ public class Boundary implements
       .replace("Extentof", "");
   }
 
+  private static boolean isUsCountyBorder(OsmElement.Relation relation) {
+    return relation.hasTag("nist:fips_code") ||
+    relation.hasTag("gnis:feature_id");
+  }
+
   @Override
   public void release() {
     regionGeometries.clear();
@@ -229,12 +234,17 @@ public class Boundary implements
         if (code != null) {
           regionNames.put(relation.id(), code);
         }
+        String borderType = null;
+        if (adminLevelValue == 6 && isUsCountyBorder(relation)) {
+          borderType = "county";
+        }
         return List.of(new BoundaryRelation(
           relation.id(),
           adminLevelValue,
           disputed,
           relation.getString("name"),
           disputed ? relation.getString("claimed_by") : null,
+          borderType,
           code,
           iso_a2
         ));
@@ -255,6 +265,7 @@ public class Boundary implements
       String iso_a2 = null;
       Set<Long> regionIds = new HashSet<>();
       boolean disputed = false;
+      boolean isUsCounty = false;
       // aggregate all borders this way is a part of - take the lowest
       // admin level, and assume it is disputed if any relation is disputed.
       for (var info : relationInfos) {
@@ -272,6 +283,9 @@ public class Boundary implements
         }
         if (minAdminLevel == 4 && iso_a2 == null) {
           iso_a2 = rel.iso3166_2;
+        }
+        if (rel.borderType == "county") {
+          isUsCounty = true;
         }
       }
 
@@ -292,6 +306,9 @@ public class Boundary implements
             minAdminLevel <= 8 ? 11 : 12;
         if (onlyOsmBoundaries && minAdminLevel <= 4) {
           minzoom = minAdminLevel == 2 ? (maritime ? 4 : 0) : 1;
+        }
+        if (minAdminLevel == 6 && isUsCounty) {
+          minzoom = 6;
         }
         if (addCountryNames && !regionIds.isEmpty()) {
           // save for later
@@ -495,6 +512,7 @@ public class Boundary implements
     boolean disputed,
     String name,
     String claimedBy,
+    String borderType,
     String iso3166alpha3,
     String iso3166_2
   ) implements OsmRelationInfo {

--- a/src/main/java/org/openmaptiles/layers/Boundary.java
+++ b/src/main/java/org/openmaptiles/layers/Boundary.java
@@ -308,7 +308,7 @@ public class Boundary implements
           minzoom = minAdminLevel == 2 ? (maritime ? 4 : 0) : 1;
         }
         if (minAdminLevel == 6 && isUsCounty) {
-          minzoom = 6;
+          minzoom = 4;
         }
         if (addCountryNames && !regionIds.isEmpty()) {
           // save for later

--- a/src/main/java/org/openmaptiles/layers/Boundary.java
+++ b/src/main/java/org/openmaptiles/layers/Boundary.java
@@ -307,7 +307,7 @@ public class Boundary implements
         if (onlyOsmBoundaries && minAdminLevel <= 4) {
           minzoom = minAdminLevel == 2 ? (maritime ? 4 : 0) : 1;
         }
-        if (minAdminLevel == 6 && isUsCounty) {
+        if ((minAdminLevel == 5 || minAdminLevel == 6) && isUsCounty) {
           minzoom = 4;
         }
         if (addCountryNames && !regionIds.isEmpty()) {
@@ -346,7 +346,8 @@ public class Boundary implements
             .setMinZoom(minzoom)
             .setAttr(Fields.CLAIMED_BY, claimedBy)
             .setAttr(Fields.COUNTRY_CODE_A2, iso_a2)
-            .setAttr(Fields.DISPUTED_NAME, editName(disputedName));
+            .setAttr(Fields.DISPUTED_NAME, editName(disputedName))
+            .setAttr(Fields.CLASS, isUsCounty ? "us_county" : null);
         }
       }
     }

--- a/src/test/java/org/openmaptiles/layers/BoundaryTest.java
+++ b/src/test/java/org/openmaptiles/layers/BoundaryTest.java
@@ -342,7 +342,7 @@ class BoundaryTest extends AbstractLayerTest {
     assertFeatures(14, List.of(Map.of(
       "_layer", "boundary",
       "_type", "line",
-      "_minzoom", 6,
+      "_minzoom", 4,
     "admin_level", 6,
     "disputed", 0,
     "maritime", 0
@@ -366,7 +366,7 @@ class BoundaryTest extends AbstractLayerTest {
     assertFeatures(14, List.of(Map.of(
       "_layer", "boundary",
       "_type", "line",
-      "_minzoom", 6,
+      "_minzoom", 4,
     "admin_level", 6,
     "disputed", 0,
     "maritime", 0

--- a/src/test/java/org/openmaptiles/layers/BoundaryTest.java
+++ b/src/test/java/org/openmaptiles/layers/BoundaryTest.java
@@ -345,7 +345,8 @@ class BoundaryTest extends AbstractLayerTest {
       "_minzoom", 4,
       "admin_level", 6,
       "disputed", 0,
-      "maritime", 0
+      "maritime", 0,
+      "class", "us_county"
     )), process(lineFeatureWithRelation(
       profile.preprocessOsmRelation(relation1),
       Map.of())));
@@ -369,7 +370,8 @@ class BoundaryTest extends AbstractLayerTest {
       "_minzoom", 4,
       "admin_level", 6,
       "disputed", 0,
-      "maritime", 0
+      "maritime", 0,
+      "class", "us_county"
     )), process(lineFeatureWithRelation(
       profile.preprocessOsmRelation(relation1),
       Map.of())));

--- a/src/test/java/org/openmaptiles/layers/BoundaryTest.java
+++ b/src/test/java/org/openmaptiles/layers/BoundaryTest.java
@@ -401,6 +401,40 @@ class BoundaryTest extends AbstractLayerTest {
   }
 
   @Test
+  void testOsmCountySharedBoundary() {
+    // County boundaries that are also part of regional boundary relations
+    // gets the class us_county
+    var relation1 = new OsmElement.Relation(1);
+    relation1.setTag("admin_level", "6");
+    relation1.setTag("type", "boundary");
+    relation1.setTag("border_type", "county");
+    relation1.setTag("boundary", "administrative");
+    relation1.setTag("name", "county1");
+    relation1.setTag("gnis:feature_id", "123");
+
+    var relation2 = new OsmElement.Relation(2);
+    relation2.setTag("admin_level", "5");
+    relation2.setTag("type", "boundary");
+    relation2.setTag("boundary", "administrative");
+    relation2.setTag("name", "Middle Tennessee");
+
+    assertFeatures(14, List.of(Map.of(
+      "_layer", "boundary",
+      "_type", "line",
+      "_minzoom", 4,
+      "disputed", 0,
+      "maritime", 0,
+      "admin_level", 5,
+      "class", "us_county"
+    )), process(lineFeatureWithRelation(
+      Stream.concat(
+        profile.preprocessOsmRelation(relation2).stream(),
+        profile.preprocessOsmRelation(relation1).stream()
+      ).toList(),
+      Map.of())));
+  }
+
+  @Test
   void testOsmBoundarySetsMaritimeFromWay() {
     var relation1 = new OsmElement.Relation(1);
     relation1.setTag("type", "boundary");

--- a/src/test/java/org/openmaptiles/layers/BoundaryTest.java
+++ b/src/test/java/org/openmaptiles/layers/BoundaryTest.java
@@ -328,6 +328,77 @@ class BoundaryTest extends AbstractLayerTest {
   }
 
   @Test
+  void testOsmUsCountyBoundaryFips() {
+    // Admin level 6 boundaries identified as US County boundaries
+    // have minzoom 6
+    var relation1 = new OsmElement.Relation(1);
+    relation1.setTag("admin_level", "6");
+    relation1.setTag("type", "boundary");
+    relation1.setTag("border_type", "county");
+    relation1.setTag("boundary", "administrative");
+    relation1.setTag("name", "county1");
+    relation1.setTag("nist:fips_code", "123");
+
+    assertFeatures(14, List.of(Map.of(
+      "_layer", "boundary",
+      "_type", "line",
+      "_minzoom", 6,
+    "admin_level", 6,
+    "disputed", 0,
+    "maritime", 0
+    )), process(lineFeatureWithRelation(
+      profile.preprocessOsmRelation(relation1),
+      Map.of())));
+  }
+
+  @Test
+  void testOsmUsCountyBoundaryGnis() {
+    // Admin level 6 boundaries identified as US County boundaries
+    // have minzoom 6
+    var relation1 = new OsmElement.Relation(1);
+    relation1.setTag("admin_level", "6");
+    relation1.setTag("type", "boundary");
+    relation1.setTag("border_type", "county");
+    relation1.setTag("boundary", "administrative");
+    relation1.setTag("name", "county1");
+    relation1.setTag("gnis:feature_id", "123");
+
+    assertFeatures(14, List.of(Map.of(
+      "_layer", "boundary",
+      "_type", "line",
+      "_minzoom", 6,
+    "admin_level", 6,
+    "disputed", 0,
+    "maritime", 0
+    )), process(lineFeatureWithRelation(
+      profile.preprocessOsmRelation(relation1),
+      Map.of())));
+  }
+
+  @Test
+  void testOsmNonUsCountyBoundary() {
+    // Admin level 6 boundaries not identified as US counties
+    // have minzoom 9
+    var relation1 = new OsmElement.Relation(1);
+    relation1.setTag("admin_level", "6");
+    relation1.setTag("type", "boundary");
+    relation1.setTag("border_type", "non-us county");
+    relation1.setTag("boundary", "administrative");
+    relation1.setTag("name", "county1");
+
+    assertFeatures(14, List.of(Map.of(
+      "_layer", "boundary",
+      "_type", "line",
+      "_minzoom", 9,
+    "admin_level", 6,
+    "disputed", 0,
+    "maritime", 0
+    )), process(lineFeatureWithRelation(
+      profile.preprocessOsmRelation(relation1),
+      Map.of())));
+  }
+
+  @Test
   void testOsmBoundarySetsMaritimeFromWay() {
     var relation1 = new OsmElement.Relation(1);
     relation1.setTag("type", "boundary");

--- a/src/test/java/org/openmaptiles/layers/BoundaryTest.java
+++ b/src/test/java/org/openmaptiles/layers/BoundaryTest.java
@@ -343,9 +343,9 @@ class BoundaryTest extends AbstractLayerTest {
       "_layer", "boundary",
       "_type", "line",
       "_minzoom", 4,
-    "admin_level", 6,
-    "disputed", 0,
-    "maritime", 0
+      "admin_level", 6,
+      "disputed", 0,
+      "maritime", 0
     )), process(lineFeatureWithRelation(
       profile.preprocessOsmRelation(relation1),
       Map.of())));
@@ -367,9 +367,9 @@ class BoundaryTest extends AbstractLayerTest {
       "_layer", "boundary",
       "_type", "line",
       "_minzoom", 4,
-    "admin_level", 6,
-    "disputed", 0,
-    "maritime", 0
+      "admin_level", 6,
+      "disputed", 0,
+      "maritime", 0
     )), process(lineFeatureWithRelation(
       profile.preprocessOsmRelation(relation1),
       Map.of())));
@@ -390,9 +390,9 @@ class BoundaryTest extends AbstractLayerTest {
       "_layer", "boundary",
       "_type", "line",
       "_minzoom", 9,
-    "admin_level", 6,
-    "disputed", 0,
-    "maritime", 0
+      "admin_level", 6,
+      "disputed", 0,
+      "maritime", 0
     )), process(lineFeatureWithRelation(
       profile.preprocessOsmRelation(relation1),
       Map.of())));


### PR DESCRIPTION
- Determine whether borders are US county or not via tags `nist:fips_code` and `gnis:feature_id`
- Include US county borders from zoom 4